### PR TITLE
feat(actions) use shared actions from common

### DIFF
--- a/.github/licenserc.yaml
+++ b/.github/licenserc.yaml
@@ -1,0 +1,48 @@
+header:
+  license:
+    spdx-id: Apache-2.0
+    content: |
+      SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+      SPDX-License-Identifier: Apache-2.0
+
+  paths: # `paths` are the path list that will be checked (and fixed) by license-eye, default is ['**'].
+    - '**'
+
+  paths-ignore:
+    - '.github/**'
+    - '*Dockerfile*'
+    - '.reuse/dep5'
+    - 'LICENSES/*.txt'
+    - '**/*.md'
+    - 'LICENSE'
+    - 'NOTICE'
+    - 'PROJECT'
+    - 'Makefile'
+    - '**/*.gitignore'
+    - '**/*.helmignore'
+    - '**/*.tpl'
+    - '**/*.keep'
+    - '**/go.mod'
+    - '**/go.sum'
+    - '**/*.lock'
+    - '**/*.json'
+    - '**/.gitkeep'
+    - '**/*.txt' 
+    - '**/nginx.conf'
+
+ 
+  comment: on-failure
+  
+  # license-location-threshold specifies the index threshold where the license header can be located,
+  # after all, a "header" cannot be TOO far from the file start.
+  license-location-threshold: 80
+
+  language:
+    JSX: 
+      extensions:
+        - ".jsx"
+      comment_style_id: SlashAsterisk
+    Hack:
+      extensions:
+        - "generate-catalog-markdown"
+      comment_style_id: Hashtag

--- a/.github/licenserc.yaml
+++ b/.github/licenserc.yaml
@@ -28,7 +28,6 @@ header:
     - '**/*.json'
     - '**/.gitkeep'
     - '**/*.txt' 
-    - '**/nginx.conf'
 
  
   comment: on-failure

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "assigneesFromCodeOwners": true,
+  "extends": [
+    "config:recommended"
+  ],
+  "constraints": {
+    "go": "1.22"
+  },
+  "packageRules": [
+    {
+      "groupName": "github actions",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major", "minor"],
+      "extends": [
+        "helpers:pinGitHubActionDigests"
+      ],
+      "minimumReleaseAge": "14 days"
+    },
+    {
+      "groupName": "npm dependencies",
+      "matchDatasources": [
+        "npm"
+      ],
+      "minimumReleaseAge": "14 days"
+    },
+    {
+      "groupName": "golang",
+      "matchDatasources": ["docker", "go-version"],
+      "matchPackagePatterns": ["golang"],
+      "minimumReleaseAge": "14 days"
+    },
+    {
+      "groupName": "kubernetes packages",
+      "groupSlug": "kubernetes-go",
+      "matchDatasources": [
+        "go"
+      ],
+      "matchUpdateTypes": ["major", "minor"],
+      "matchPackagePrefixes": [
+        "k8s.io/api",
+        "k8s.io/apiextensions-apiserver",
+        "k8s.io/apimachinery",
+        "k8s.io/apiserver",
+        "k8s.io/cli-runtime",
+        "k8s.io/client-go",
+        "k8s.io/cloud-provider",
+        "k8s.io/cluster-bootstrap",
+        "k8s.io/code-generator",
+        "k8s.io/component-base",
+        "k8s.io/controller-manager",
+        "k8s.io/cri-api",
+        "k8s.io/csi-translation-lib",
+        "k8s.io/kube-aggregator",
+        "k8s.io/kube-controller-manager",
+        "k8s.io/kube-proxy",
+        "k8s.io/kube-scheduler",
+        "k8s.io/kubectl",
+        "k8s.io/kubelet",
+        "k8s.io/legacy-cloud-providers",
+        "k8s.io/metrics",
+        "k8s.io/mount-utils",
+        "k8s.io/pod-security-admission",
+        "k8s.io/sample-apiserver",
+        "k8s.io/sample-cli-plugin",
+        "k8s.io/sample-controller",
+        "sigs.k8s.io/controller-runtime"
+      ],
+      "minimumReleaseAge": "14 days"
+    }
+  ],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
+  ],
+  "separateMinorPatch": true,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["Makefile$", "\\.sh$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s.+?_(VERSION|version) *[?:]?= *\"?(?<currentValue>.+?)\"?\\s"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,28 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+  schedule:
+    - cron: '20 08 * * 1'
+
+jobs:
+  codeql:
+    permissions:
+        security-events: write
+        actions: read
+        contents: read
+    uses: cloudoperators/common/.github/workflows/shared-codeql.yaml@main
+    with:
+      runs-on: "['default']"
+      language: "['go']"
+      go-check: true
+      go-version: "['1.22']"
+      node-check: false
+      # node-version : "['node']"
+      # fail-fast: false  
+      # timeout: 30
+      autobuild: true
+      # build_query: "make something"

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -10,11 +10,11 @@ env:
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
   # Comma separated list of platforms to build the image for.
-  PLATFORMS: linux/amd64
+  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [ default ]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -35,6 +35,12 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha
+          labels: |
+            org.opencontainers.image.title=Concourse resource for artifacts in an OCI registry
+            org.opencontainers.image.description=Fetches, verifies and publishes Helm Charts from a running OCI registry.
+            org.opencontainers.image.url=https://github.com/cloudoperators/concourse-oci-helm-chart-resource
+            org.opencontainers.image.source=https://github.com/cloudoperators/concourse-oci-helm-chart-resource
+            org.opencontainers.image.documentation=https://github.com/cloudoperators/concourse-oci-helm-chart-resource/tree/main/README.md
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
@@ -43,3 +49,31 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+  
+  vulnerability-scan:
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+    name: Vulnerability Scan
+    needs: build
+    runs-on: [ default ]
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        if: success()
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -1,0 +1,8 @@
+name: Check & Fix License Header
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build-license-eye:
+    uses: cloudoperators/common/.github/workflows/shared-license.yaml@main

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -1,6 +1,5 @@
 name: Check & Fix License Header
 on:
-  workflow_dispatch: {}
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -8,4 +7,4 @@ jobs:
   build-license-eye:
     permissions:
       contents: write # Only used when `apply_header: true` else the permission is `read` see: https://github.com/cloudoperators/common/blob/8f15c13b6f4c1631c7e6f6dff5c3300452e9b5b6/.github/workflows/shared-license.yaml#L21-L22
-    uses: kengou4/common/.github/workflows/play-shared-license.yaml@main
+    uses: cloudoperators/common/.github/workflows/shared-license.yaml@main

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -1,8 +1,11 @@
 name: Check & Fix License Header
 on:
+  workflow_dispatch: {}
   pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
   build-license-eye:
-    uses: cloudoperators/common/.github/workflows/shared-license.yaml@main
+    permissions:
+      contents: write # Only used when `apply_header: true` else the permission is `read` see: https://github.com/cloudoperators/common/blob/8f15c13b6f4c1631c7e6f6dff5c3300452e9b5b6/.github/workflows/shared-license.yaml#L21-L22
+    uses: kengou4/common/.github/workflows/play-shared-license.yaml@main

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2022 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: REUSE Compliance Check
+
+on: [pull_request]
+
+jobs:
+  reuse:
+    uses: cloudoperators/common/.github/workflows/shared-reuse.yaml@main

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,11 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "36 1 * * *"
+
+jobs:
+  stale:
+    permissions:
+      issues: write
+      pull-requests: write
+    uses: cloudoperators/common/.github/workflows/shared-stale.yaml@main

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM golang:1.22 as build
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22 as build
 
 WORKDIR /concourse-oci-helm-chart-resource
 COPY . .
 RUN make build
 
-FROM alpine AS run
+FROM --platform=${BUILDPLATFORM:-linux/amd64} alpine:3.20.3 AS run
 
-LABEL org.opencontainers.image.source = "https://github.com/cloudoperators/concourse-oci-helm-chart-resource"
+# upgrade all installed packages to fix potential CVEs in advance
+RUN apk upgrade --no-cache --no-progress \
+  && apk del --no-cache --no-progress apk-tools alpine-keys
 
 # Required by concourse resource. Copy explicitly.
 COPY --from=build /concourse-oci-helm-chart-resource/bin/check /opt/resource/check

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.


### PR DESCRIPTION
This PR is changing 2 actions to use load them from [common](https://github.com/cloudoperators/common) as shared `GitHub Action`
Adding renovate config to the repo
Add vulnerability-scan to docker build
Add multi arch image build