### PR TITLE
feat(core): add tag, tag_regex and created_at_sort source fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ resources:
       chart_name: my-chart
 ```
 
+### Source Parameters
+
+| Parameter         | Type   | Required | Description                                                                                                                                            |
+| ----------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `registry`        | string | yes      | OCI registry hostname (e.g. `ghcr.io`).                                                                                                                |
+| `repository`      | string | yes      | Repository path within the registry (e.g. `my-org/my-charts`).                                                                                         |
+| `chart_name`      | string | yes      | Name of the Helm chart to check/download.                                                                                                              |
+| `auth_username`   | string | optional | Username for basic authentication. Requires `auth_password` to be set.                                                                                 |
+| `auth_password`   | string | optional | Password for basic authentication. Requires `auth_username` to be set.                                                                                 |
+| `tag`             | string | optional | A specific tag to check. Mutually exclusive with `tag_regex`.                                                                                          |
+| `tag_regex`       | string | optional | A regular expression to filter tags by partial or full match (e.g. `^0.0.0-` matches all pre-release builds). When set, semver sorting is skipped. |
+| `created_at_sort` | bool   | optional | Sort matched tags by OCI image creation timestamp (ascending, newest last). Requires `tag_regex` or `tag` to be set.                                   |
+
 #### Authentication
 
 The resource supports two ways of authenticating against the registry:
@@ -50,3 +63,21 @@ Places the packaged Helm chart and the metadata file in the destination director
 ### out
 
 * Currently not supported. Use `helm push` to push Helm charts to an OCI registry.
+
+## Examples
+
+### Track pre-release builds sorted by creation time
+
+```yaml
+resources:
+  - name: my-chart-prerelease
+    type: oci-registry
+    source:
+      registry: ghcr.io
+      repository: my-org/my-charts
+      chart_name: my-chart
+      tag_regex: "^0.0.0-"
+      created_at_sort: true
+```
+
+This example uses `tag_regex` to filter for pre-release tags matching the pattern `^0.0.0-` and sorts them by OCI image creation timestamp (ascending, newest last). Note that `tag_regex` uses Go's `regexp.MatchString` which performs partial/substring matching — use `^` and `$` anchors as needed for full match patterns.

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,8 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pkg/errors v0.9.1
+	golang.org/x/sync v0.14.0
 	oras.land/oras-go/v2 v2.6.0
 )
 
-require (
-	github.com/opencontainers/go-digest v1.0.0 // indirect
-	golang.org/x/sync v0.14.0 // indirect
-)
+require github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/pkg/resource/check.go
+++ b/pkg/resource/check.go
@@ -7,10 +7,13 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"slices"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote"
 )
@@ -33,8 +36,19 @@ func Check(ctx context.Context, request CheckRequest) (*CheckResponse, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create repository client")
 	}
+	if request.Source.Tag != "" {
+		return checkBySingleTag(ctx, request, repo)
+	}
+	if request.Source.TagRegex != "" {
+		return checkByTagRegex(ctx, request, repo)
+	}
+	return checkBySemver(ctx, request, repo)
+}
 
-	// Fetch repository tags
+// checkBySemver is the original check implementation: fetches all tags, parses
+// them as semver, sorts ascending, and trims at the requested version or returns
+// the last 10.
+func checkBySemver(ctx context.Context, request CheckRequest, repo *remote.Repository) (*CheckResponse, error) {
 	allTags, err := registry.Tags(ctx, repo)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch tags")
@@ -57,11 +71,7 @@ func Check(ctx context.Context, request CheckRequest) (*CheckResponse, error) {
 		}
 	} else {
 		// if no version was requested, return the latest 10 versions
-		startIndex := len(sortedSemvers) - 10
-		if startIndex < 0 {
-			startIndex = 0
-		}
-		sortedSemvers = sortedSemvers[startIndex:]
+		sortedSemvers = sortedSemvers[max(0, len(sortedSemvers)-10):]
 	}
 
 	if len(sortedSemvers) == 0 {
@@ -75,9 +85,95 @@ func Check(ctx context.Context, request CheckRequest) (*CheckResponse, error) {
 	return &resolvedVersions, nil
 }
 
+// checkBySingleTag returns a CheckResponse containing exactly one version for the
+// tag specified in source.Tag.
+func checkBySingleTag(ctx context.Context, request CheckRequest, repo *remote.Repository) (*CheckResponse, error) {
+	digest, err := getDigestForTag(ctx, repo, request.Source.Tag)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to fetch digest for tag %q", request.Source.Tag))
+	}
+	return &CheckResponse{Version{Tag: request.Source.Tag, Digest: digest}}, nil
+}
+
+// checkByTagRegex filters repository tags by source.TagRegex, optionally sorts
+// them by OCI image creation time (source.CreatedAtSort), then applies the same
+// windowing logic as the semver path (trim at requested version or return last 10).
+func checkByTagRegex(ctx context.Context, request CheckRequest, repo *remote.Repository) (*CheckResponse, error) {
+	re, err := regexp.Compile(request.Source.TagRegex)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to compile tag_regex %q", request.Source.TagRegex))
+	}
+
+	tags, err := registry.Tags(ctx, repo)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch tags")
+	}
+
+	// Filter by regex
+	matched := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if re.MatchString(t) {
+			matched = append(matched, t)
+		}
+	}
+
+	if len(matched) == 0 {
+		return nil, fmt.Errorf("no tags matched tag_regex %q in source %s", request.Source.TagRegex, request.Source.String())
+	}
+
+	// Sort by creation timestamp if requested, otherwise keep registry order
+	if request.Source.CreatedAtSort {
+		times := make([]time.Time, len(matched))
+		g, gctx := errgroup.WithContext(ctx)
+		// Limit concurrent OCI manifest fetches to avoid overwhelming the registry
+		// with a burst of requests when many tags match the regex.
+		g.SetLimit(10)
+		for i, tag := range matched {
+			g.Go(func() error {
+				ts, err := getCreatedAtForTag(gctx, repo, tag)
+				if err != nil {
+					return errors.Wrap(err, fmt.Sprintf("failed to get created_at for tag %q", tag))
+				}
+				if ts != nil {
+					times[i] = *ts
+				}
+				return nil
+			})
+		}
+		if err := g.Wait(); err != nil {
+			return nil, err
+		}
+		tagToTime := make(map[string]time.Time, len(matched))
+		for i, tag := range matched {
+			tagToTime[tag] = times[i]
+		}
+		slices.SortStableFunc(matched, func(a, b string) int {
+			return tagToTime[a].Compare(tagToTime[b])
+		})
+	}
+
+	// Trim at requested version (by tag equality), same windowing as semver path
+	if request.Version != nil {
+		for i, t := range matched {
+			if t == request.Version.Tag {
+				matched = matched[i:]
+				break
+			}
+		}
+	} else {
+		matched = matched[max(0, len(matched)-10):]
+	}
+
+	resolved, err := resolveTagDigests(ctx, matched, repo)
+	if err != nil {
+		return nil, err
+	}
+	return &resolved, nil
+}
+
 func sortBySemver(allTags []string) []semver.Version {
 	allVersions := make([]semver.Version, len(allTags))
-	var j = 0
+	j := 0
 	for _, tag := range allTags {
 		v, err := semver.NewVersion(tag)
 		if err != nil {
@@ -90,7 +186,7 @@ func sortBySemver(allTags []string) []semver.Version {
 	slices.SortStableFunc(allVersions, func(i, j semver.Version) int {
 		return i.Compare(&j)
 	})
-	return allVersions
+	return allVersions[:j]
 }
 
 func resolveImageDigests(ctx context.Context, sortedSemvers []semver.Version, repo *remote.Repository) (CheckResponse, error) {
@@ -103,4 +199,17 @@ func resolveImageDigests(ctx context.Context, sortedSemvers []semver.Version, re
 		resolvedVersions[i] = Version{Tag: version.Original(), Digest: digest}
 	}
 	return resolvedVersions, nil
+}
+
+// resolveTagDigests resolves OCI digests for a list of raw tag strings.
+func resolveTagDigests(ctx context.Context, tags []string, repo *remote.Repository) (CheckResponse, error) {
+	resolved := make(CheckResponse, len(tags))
+	for i, tag := range tags {
+		digest, err := getDigestForTag(ctx, repo, tag)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("failed to fetch digest for tag %q", tag))
+		}
+		resolved[i] = Version{Tag: tag, Digest: digest}
+	}
+	return resolved, nil
 }

--- a/pkg/resource/repo.go
+++ b/pkg/resource/repo.go
@@ -5,8 +5,11 @@ package resource
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"time"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
@@ -33,7 +36,7 @@ func newRepositoryForSource(_ context.Context, s Source) (*remote.Repository, er
 		Client: retry.DefaultClient,
 		Cache:  auth.NewCache(),
 	}
-	// 	Set up credentials from docker.
+	// Set up credentials from docker.
 	storeOpts := credentials.StoreOptions{}
 	credStore, err := credentials.NewStoreFromDocker(storeOpts)
 	if err != nil {
@@ -58,4 +61,35 @@ func getDigestForTag(ctx context.Context, repo *remote.Repository, tag string) (
 		return "", err
 	}
 	return desc.Digest.String(), nil
+}
+
+// getCreatedAtForTag fetches the OCI image config for the given tag and returns
+// the creation timestamp recorded in it. Returns nil if the config has no
+// Created field set.
+func getCreatedAtForTag(ctx context.Context, repo *remote.Repository, tag string) (*time.Time, error) {
+	// FetchReference goes directly to the manifests endpoint for the tag.
+	_, manifestReader, err := repo.FetchReference(ctx, tag)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to fetch manifest for tag %q", tag)
+	}
+	defer manifestReader.Close()
+
+	var manifest ocispec.Manifest
+	if err := json.NewDecoder(manifestReader).Decode(&manifest); err != nil {
+		return nil, errors.Wrapf(err, "failed to parse manifest for tag %q", tag)
+	}
+
+	// Fetch the config blob by digest via the blobs endpoint.
+	configReader, err := repo.Blobs().Fetch(ctx, manifest.Config)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to fetch config blob for tag %q", tag)
+	}
+	defer configReader.Close()
+
+	var image ocispec.Image
+	if err := json.NewDecoder(configReader).Decode(&image); err != nil {
+		return nil, errors.Wrapf(err, "failed to parse image config for tag %q", tag)
+	}
+
+	return image.Created, nil
 }

--- a/pkg/resource/types.go
+++ b/pkg/resource/types.go
@@ -13,6 +13,10 @@ type Source struct {
 	Repository string `json:"repository"`
 	ChartName  string `json:"chart_name"`
 
+	Tag           string `json:"tag,omitempty"`
+	TagRegex      string `json:"tag_regex,omitempty"`
+	CreatedAtSort bool   `json:"created_at_sort,omitempty"`
+
 	AuthUsername string `json:"auth_username,omitempty"`
 	AuthPassword string `json:"auth_password,omitempty"`
 }
@@ -26,6 +30,12 @@ func (s *Source) Validate() error {
 	}
 	if s.ChartName == "" {
 		return errors.New("chart_name cannot be empty")
+	}
+	if s.Tag != "" && s.TagRegex != "" {
+		return errors.New("tag and tag_regex are mutually exclusive")
+	}
+	if s.CreatedAtSort && s.TagRegex == "" {
+		return errors.New("created_at_sort requires tag_regex to be set")
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

Helm charts published as pre-release versions in the form 0.0.0-{git-sha} cannot be tracked reliably with the existing semver-based check. Semver treats the pre-release identifier as a string and sorts it lexicographically, meaning the order of versions in the check response does not reflect the actual release order.

This change adds tag_regex and created_at_sort source fields (modelled after the https://github.com/concourse/registry-image-resource) to opt out of semver sorting entirely. When tag_regex is set, tags are filtered by the given regular expression and — if created_at_sort: true — sorted by the OCI image creation timestamp instead, which correctly reflects push order.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

```bash
> make build
> echo '{
      "source": {
        "registry": "ghcr.io",
        "repository": "ironcore-dev/charts",
        "chart_name": "network-operator",
        "tag_regex": "^0.0.0-*",
        "created_at_sort": true
      }
    }' | ./bin/check
[...]
```

Then compare against the released charts in https://github.com/ironcore-dev/network-operator/pkgs/container/charts%2Fnetwork-operator.

## Added to documentation?

- [x] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes (there are not test files currently ;)
