### PR TITLE
fix(ci): grant permissions to validate pr title and fix REUSE config

### DIFF
--- a/.github/workflows/ci-pr-title.yaml
+++ b/.github/workflows/ci-pr-title.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  pull-requests: read
+
 jobs:
   title-lint:
     name: Validate PR title

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -12,3 +12,9 @@ path = "**"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 SAP SE or an SAP affiliate company and Greenhouse contributors"
 SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ".github/licenserc.yaml"
+precedence = "override"
+SPDX-FileCopyrightText = "2024 SAP SE or an SAP affiliate company and Greenhouse contributors"
+SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
## Description

Grants the missing permissions to the workflow for validating the PR title.

Also fixes the REUSE compliance check failure caused by the `pattern` field in `.github/licenserc.yaml` containing `Apache-2\.0` — a regex escape that the REUSE tool misparses as an invalid SPDX expression. An `override` annotation in `REUSE.toml` tells the tool to use the declared license metadata instead of scanning the file contents.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Check should run on this PR without permission issues.

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes